### PR TITLE
Allow arbitrary salt lengths in YescryptSettings ctor

### DIFF
--- a/tests/YescryptTests.cs
+++ b/tests/YescryptTests.cs
@@ -12,7 +12,11 @@ namespace tests
             Assert.IsTrue(Yescrypt.CheckPasswd(Encoding.ASCII.GetBytes("foo"), "$y$j9T$IYOtk1P7X7XerR2MxSBt41$ylOTRMdaL7amUytGWDGmMeCvzk3yPxMwliVqAMmeuUB"));
             Assert.IsFalse(Yescrypt.CheckPasswd(Encoding.ASCII.GetBytes("foobar"), "$y$j9T$IYOtk1P7X7XerR2MxSBt41$ylOTRMdaL7amUytGWDGmMeCvzk3yPxMwliVqAMmeuUB"));
             Assert.IsTrue(Yescrypt.CheckPasswd(Encoding.UTF8.GetBytes("klâwen"), "$y$j9T$gdl4VsceJ0dcK65iQQZzc0$7b08F6h5QwLdzQVhJlbT1LakWThuW7MLEGrRV5S.X0C"));
+            
+            // Test different salt lengths (23-25 characters before encoding)
+            Assert.IsTrue(Yescrypt.CheckPasswd(Encoding.UTF8.GetBytes("foobar"), "$y$j9T$iemju3R6WTIkO45Q5cNJB1$OMiCs4T6oPqi8sUjuhtLnlMXPbbfDwUEpK8KlifZQO9"));
             Assert.IsTrue(Yescrypt.CheckPasswd(Encoding.UTF8.GetBytes("test123"), "$y$j9T$Uld6DeBZ9Yn3FhvyAdwEGiam$/SgUfzYuKXiMVUDyvVJS7kRiwfCHcF6juRglqHR00Y7"));
+            Assert.IsTrue(Yescrypt.CheckPasswd(Encoding.UTF8.GetBytes("foobar"), "$y$j9T$pWg/Dy73M0YFPg7hllxIE.$Z.heZ9FROBoqVhzRYBkbQ/hhDwEvIK4hByhpHwpjeM5"));
         }
 
         [TestMethod()]

--- a/tests/YescryptTests.cs
+++ b/tests/YescryptTests.cs
@@ -12,6 +12,7 @@ namespace tests
             Assert.IsTrue(Yescrypt.CheckPasswd(Encoding.ASCII.GetBytes("foo"), "$y$j9T$IYOtk1P7X7XerR2MxSBt41$ylOTRMdaL7amUytGWDGmMeCvzk3yPxMwliVqAMmeuUB"));
             Assert.IsFalse(Yescrypt.CheckPasswd(Encoding.ASCII.GetBytes("foobar"), "$y$j9T$IYOtk1P7X7XerR2MxSBt41$ylOTRMdaL7amUytGWDGmMeCvzk3yPxMwliVqAMmeuUB"));
             Assert.IsTrue(Yescrypt.CheckPasswd(Encoding.UTF8.GetBytes("klâwen"), "$y$j9T$gdl4VsceJ0dcK65iQQZzc0$7b08F6h5QwLdzQVhJlbT1LakWThuW7MLEGrRV5S.X0C"));
+            Assert.IsTrue(Yescrypt.CheckPasswd(Encoding.UTF8.GetBytes("test123"), "$y$j9T$Uld6DeBZ9Yn3FhvyAdwEGiam$/SgUfzYuKXiMVUDyvVJS7kRiwfCHcF6juRglqHR00Y7"));
         }
 
         [TestMethod()]

--- a/yescrypt/B64StringReader.cs
+++ b/yescrypt/B64StringReader.cs
@@ -112,8 +112,11 @@ namespace Fasterlimit.Yescrypt
                     val >>= 8;
                 }
             }
+
+            bool hasPadding = false;
             if (bits > 0 )
             {
+                hasPadding = true;
                 uint val = ReadUint32Bits(bits);
                 for (int i = 0; i < bits / 6; i++)
                 {
@@ -124,7 +127,7 @@ namespace Fasterlimit.Yescrypt
             
             if(rvalIndex < rval.Length)
             {
-                Array.Resize(ref rval, rvalIndex - 1);
+                Array.Resize(ref rval, rvalIndex - (hasPadding ? 1 : 0));
             }
 
             return rval;

--- a/yescrypt/YescryptSettings.cs
+++ b/yescrypt/YescryptSettings.cs
@@ -22,7 +22,6 @@ namespace Fasterlimit.Yescrypt
             p = 1;
             t = 0;
             g = 0;
-            salt = new byte[16];
             key = new byte[32];
         }
 
@@ -100,7 +99,8 @@ namespace Fasterlimit.Yescrypt
 
             // Decode Salt
             reader = new B64StringReader(parts[3]);
-            salt = reader.ReadBytes(16);
+            var saltLen = (int)Math.Ceiling(parts[3].Length / 1.375);
+            salt = reader.ReadBytes(saltLen);
 
             // Decode Key
             reader = new B64StringReader(parts[4]);

--- a/yescrypt/YescryptSettings.cs
+++ b/yescrypt/YescryptSettings.cs
@@ -100,8 +100,7 @@ namespace Fasterlimit.Yescrypt
 
             // Decode Salt
             reader = new B64StringReader(parts[3]);
-            var saltLen = (int)Math.Ceiling(parts[3].Length / 1.375);
-            salt = reader.ReadBytes(saltLen);
+            salt = reader.ReadBytes(64); // read up to maximum of 512 bits of salt
 
             // Decode Key
             reader = new B64StringReader(parts[4]);

--- a/yescrypt/YescryptSettings.cs
+++ b/yescrypt/YescryptSettings.cs
@@ -22,6 +22,7 @@ namespace Fasterlimit.Yescrypt
             p = 1;
             t = 0;
             g = 0;
+            salt = new byte[16];
             key = new byte[32];
         }
 


### PR DESCRIPTION
Hi,

the current YescryptSettings implementation is causing problems with systems where the salt is not exactly 16 bytes long. For example, this is the case for Anaconda-based Linux distributions - the generated hash during user creation is ~18 bytes long, thus we cannot validate those passwords, see: https://github.com/rhinstaller/anaconda/blob/6f793d0d68fc15c321b25c50a10ab5f556349285/pyanaconda/core/users.py#L52

With this update, salt array is sized dynamically, based on the input size.